### PR TITLE
fix install UnicodeDecodeError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", "r") as f:
+with open("README.md", "r",encoding="utf-8") as f:
     long_description = f.read()
 
 setuptools.setup(


### PR DESCRIPTION
When use `pip install sesd` , I got 

```shell
 UnicodeDecodeError: 'gbk' codec can't decode byte 0x93 in position 991: illegal multibyte sequence
```

I simply add encoding setting to fix it.